### PR TITLE
Update using-dataflows-with-on-premises-data.md

### DIFF
--- a/powerquery-docs/dataflows/using-dataflows-with-on-premises-data.md
+++ b/powerquery-docs/dataflows/using-dataflows-with-on-premises-data.md
@@ -101,7 +101,7 @@ You can change the enterprise gateway used for a given dataflow and change the g
 
    ![Image showing the manage gateways selection in Power BI service](media/manage-gateways-power-bi.png)
 
-2. To add a user to the gateway, select the **Administrators** table and enter the email address of the user you would like to add as an administrator. Using gateways in dataflows requires Admin permission on the gateway. Admins have full control of the gateway, including adding users, setting permissions, creating connections to all available data sources, and deleting the gateway.
+2. To add a user to the gateway, select the **Administrators** table and enter the email address of the user you would like to add as an administrator.Creating or modifying data sources in Dataflows requires Admin permissions to the gateway. Admins have full control of the gateway, including adding users, setting permissions, creating connections to all available data sources, and deleting the gateway.
 
 ### Power Apps gateway permissions
 

--- a/powerquery-docs/dataflows/using-dataflows-with-on-premises-data.md
+++ b/powerquery-docs/dataflows/using-dataflows-with-on-premises-data.md
@@ -101,7 +101,7 @@ You can change the enterprise gateway used for a given dataflow and change the g
 
    ![Image showing the manage gateways selection in Power BI service](media/manage-gateways-power-bi.png)
 
-2. To add a user to the gateway, select the **Administrators** table and enter the email address of the user you would like to add as an administrator.Creating or modifying data sources in Dataflows requires Admin permissions to the gateway. Admins have full control of the gateway, including adding users, setting permissions, creating connections to all available data sources, and deleting the gateway.
+2. To add a user to the gateway, select the **Administrators** table and enter the email address of the user you would like to add as an administrator.Creating or modifying data sources in dataflows requires Admin permissions to the gateway. Admins have full control of the gateway, including adding users, setting permissions, creating connections to all available data sources, and deleting the gateway.
 
 ### Power Apps gateway permissions
 


### PR DESCRIPTION
The wording in "View and manage gateway permissions" section currently states "Using gateways in dataflows requires Admin permission on the gateway."  that is misleading and should be revised as "Creating or modifying data sources in Dataflows requires Admin permissions to the gateway" .