### PR TITLE
Updating 'Helper Functions' to be in sync with latest Table.GenerateByPage revision

### DIFF
--- a/powerquery-docs/HelperFunctions.md
+++ b/powerquery-docs/HelperFunctions.md
@@ -171,7 +171,10 @@ Table.GenerateByPage = (getNextPage as function) as table =>
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-        else        
+		// check for empty first table
+		else if (Table.IsEmpty(firstRow[Column1])) then
+			firstRow[Column1]
+        else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),
                 Value.Type(firstRow[Column1])

--- a/powerquery-docs/HelperFunctions.md
+++ b/powerquery-docs/HelperFunctions.md
@@ -171,9 +171,9 @@ Table.GenerateByPage = (getNextPage as function) as table =>
         // otherwise set the table type based on the columns of the first page
         if (firstRow = null) then
             Table.FromRows({})
-		// check for empty first table
-		else if (Table.IsEmpty(firstRow[Column1])) then
-			firstRow[Column1]
+	// check for empty first table
+        else if (Table.IsEmpty(firstRow[Column1])) then
+            firstRow[Column1]
         else
             Value.ReplaceType(
                 Table.ExpandTableColumn(tableOfPages, "Column1", Table.ColumnNames(firstRow[Column1])),


### PR DESCRIPTION
This docs page is out of sync with https://github.com/microsoft/DataConnectors/blob/master/samples/TripPin/9-TestConnection/Table.GenerateByPage.pqm. The latter contains a "first table is empty" check which is missing from the docs page.