### PR TITLE
Term Correction: Metadata -> Literal Attribute

### DIFF
--- a/powerquery-docs/HandlingDataAccess.md
+++ b/powerquery-docs/HandlingDataAccess.md
@@ -35,7 +35,7 @@ shared HelloWorld.Contents = (optional message as text) =>
 
 ## Data Source Kind
 
-Functions marked as `shared` in your extension can be associated with a specific data source by including a `DataSource.Kind` metadata record on the function with the name of a Data Source definition record. 
+Functions marked as `shared` in your extension can be associated with a specific data source by including a `DataSource.Kind` literal attribute on the function with the name of a Data Source definition record. 
 The Data Source record defines the authentication types supported by your data source, and basic branding information (like the display name / label).
 The name of the record becomes is unique identifier. 
 


### PR DESCRIPTION
Current docs incorrectly refer to the `[DataSource.Kind="HelloWorld"]`-style annotation on a section member as metadata. Per the [language spec](https://docs.microsoft.com/en-us/powerquery-m/m-spec-consolidated-grammar#section-documents), I believe the correct term here is "literal attribute."

While at first glance metadata and literal attributes may appear similar, their syntax rules and behavior are different. 