### PR TITLE
Remove ODBC-only note from DirectQuery config param

### DIFF
--- a/powerquery-docs/HandlingDataAccess.md
+++ b/powerquery-docs/HandlingDataAccess.md
@@ -98,7 +98,7 @@ The following table lists the fields for your Publish record.
 | Category            | text    | Where the extension should be displayed in the **Get Data** dialog. Currently the only category values with special handing are `Azure` and `Database`. All other values will end up under the Other category. |
 | Beta                | logical | **(optional)** When set to true, the UI will display a Preview/Beta identifier next to your connector name and a warning dialog that the implementation of the connector is subject to breaking changes. |
 | LearnMoreUrl        | text    | **(optional)** Url to website containing more information about this data source or connector. |
-| SupportsDirectQuery | logical | **(optional)** Enables Direct Query for your extension.<br>**This is currently only supported for ODBC extensions.** |
+| SupportsDirectQuery | logical | **(optional)** Enables Direct Query for your extension. |
 | SourceImage         | record  | **(optional)** A record containing a list of binary images (sourced from the extension file using the **Extension.Contents** method). The record contains two fields (Icon16, Icon32), each with its own list. Each icon should be a different size. |
 | SourceTypeImage     | record  | **(optional)** Similar to SourceImage, except the convention for many out of the box connectors is to display a sheet icon with the source specific icon in the bottom right corner. Having a different set of icons for SourceTypeImage is optional&mdash;many extensions simply reuse the same set of icons for both fields. |
 | | | |


### PR DESCRIPTION
Per https://github.com/microsoft/DataConnectors/issues/246#issuecomment-539735441:
> Direct Query absolutely works for non-ODBC sources.

Updating this page to reflect.