### PR TITLE
Update SharePointOnlineList.md

### DIFF
--- a/powerquery-docs/Connectors/SharePointOnlineList.md
+++ b/powerquery-docs/Connectors/SharePointOnlineList.md
@@ -101,7 +101,7 @@ The default view is what you'll see when looking at the list online in whichever
    [ ![A screen showing a sample of SharePoint Online list default view.](./media/sharepoint-online-list/sharepointonlinelistsettings.png) ](./media/sharepoint-online-list/sharepointonlinelistsettings.png#lightbox)
    
 >[!Note]
-> If you set Calendar view or Board view as default view in SharePont site, SharePoint will only return the columns in the current view. Under this scenario, Power BI won't be able to retrieve all the columns of the list even though you choose All option. This is by design.
+> If you set the default view in your SharePoint site to **Calendar** view or **Board** view, SharePoint only returns the columns shown in the selected view. In this scenario, Power BI will not retrieve all the columns in the list, even though you choose **All** option. This is by design.
 
 ## Troubleshooting
 

--- a/powerquery-docs/Connectors/SharePointOnlineList.md
+++ b/powerquery-docs/Connectors/SharePointOnlineList.md
@@ -99,6 +99,9 @@ The **All** view includes all user created and system defined columns. You can s
 The default view is what you'll see when looking at the list online in whichever view you've set as *Default* in your settings. If you edit this view to add or remove either user created or system defined columns, or by creating a new view and setting it as default, these changes will propagate through the connector.
 
    [ ![A screen showing a sample of SharePoint Online list default view.](./media/sharepoint-online-list/sharepointonlinelistsettings.png) ](./media/sharepoint-online-list/sharepointonlinelistsettings.png#lightbox)
+   
+>[!Note]
+> If you set Calendar view or Board view as default view in SharePont site, SharePoint will only return the columns in the current view. Under this scenario, Power BI won't be able to retrieve all the columns of the list even though you choose All option. This is by design.
 
 ## Troubleshooting
 


### PR DESCRIPTION
add the below note:
If you set Calendar view or Board view as default view in SharePont site, SharePoint will only return the columns in the current view. Under this scenario, Power BI won't be able to retrieve all the columns of the list even though you choose All option. This is by design.

per the confirmation by product group and SEE of sharepoint online list team, this is by design. if you need more details, please ping me on teams<v-gaoju@microsoft.com>.