### PR TITLE
Enhancing the error experience for Extension.LoadFunction

### DIFF
--- a/powerquery-docs/samples/TripPin/7-AdvancedSchema/README.md
+++ b/powerquery-docs/samples/TripPin/7-AdvancedSchema/README.md
@@ -248,12 +248,20 @@ At this point, your extension almost has as much "common" code as TripPin connec
 The code to do this is included in the snippet below:
 
 ```
-Extension.LoadFunction = (name as text) =>
-    let
-        binary = Extension.Contents(name),
-        asText = Text.FromBinary(binary)
-    in
-        Expression.Evaluate(asText, #shared);
+Extension.LoadFunction = (fileName as text) =>
+  let
+      binary = Extension.Contents(fileName),
+      asText = Text.FromBinary(binary)
+  in
+      try
+        Expression.Evaluate(asText, #shared)
+      catch (e) =>
+        error [
+            Reason = "Extension.LoadFunction Failure",
+            Message.Format = "Loading '#{0}' failed - '#{1}': '#{2}'",
+            Message.Parameters = {fileName, e[Reason], e[Message]},
+            Detail = [File = fileName, Error = e]
+        ];
 
 Table.ChangeType = Extension.LoadFunction("Table.ChangeType.pqm");
 Table.GenerateByPage = Extension.LoadFunction("Table.GenerateByPage.pqm");

--- a/powerquery-docs/samples/TripPin/7-AdvancedSchema/README.md
+++ b/powerquery-docs/samples/TripPin/7-AdvancedSchema/README.md
@@ -5,7 +5,7 @@ author: ptyx507x
 
 
 ms.topic: tutorial
-ms.date: 5/15/2020
+ms.date: 11/12/2022
 ms.author: miescobar
 ---
 


### PR DESCRIPTION
If a `.pqm` file contains a syntax problem, `Expression.Evaluate` will raise an appropriate error. However, this error does not indicate which `.pqm` file in the extension contains the error.

This update wraps `Expression.Evaluate`'s error with details on where it came from and gives it a consolidated, "friendly" error message.

Derived from https://github.com/microsoft/vscode-powerquery-sdk/issues/171