### PR TITLE
Removing inline Table.ToNavigationTable definition

### DIFF
--- a/powerquery-docs/samples/trippin/3-navtables/readme.md
+++ b/powerquery-docs/samples/trippin/3-navtables/readme.md
@@ -93,7 +93,7 @@ TripPin.Contents("https://services.odata.org/v4/TripPinService/")
 
 ## Creating a navigation table
 
-You'll use the handy [Table.ToNavigationTable](../../../helper-functions#tabletonavigationtable) function to format your static table into something that Power Query will recognize as a navigation table. Since this function is not part of Power Query's standard library, you'll need to copy its source code into your .pq file.
+You'll use the handy [Table.ToNavigationTable](../../../helper-functions.md#tabletonavigationtable) function to format your static table into something that Power Query will recognize as a navigation table. Since this function is not part of Power Query's standard library, you'll need to copy its source code into your .pq file.
 
 With this helper function in place, next update your `TripPinNavTable` function to add the navigation table fields.
 

--- a/powerquery-docs/samples/trippin/3-navtables/readme.md
+++ b/powerquery-docs/samples/trippin/3-navtables/readme.md
@@ -93,34 +93,9 @@ TripPin.Contents("https://services.odata.org/v4/TripPinService/")
 
 ## Creating a navigation table
 
-You'll use the handy [Table.ToNavigationTable](../../../handling-navigation-tables.md#tabletonavigationtable) function to format your static table into something that Power Query will recognize as a navigation table.
+You'll use the handy [Table.ToNavigationTable](../../../helper-functions#tabletonavigationtable) function to format your static table into something that Power Query will recognize as a navigation table. Since this function is not part of Power Query's standard library, you'll need to copy its source code into your .pq file.
 
-```powerquery-m
-Table.ToNavigationTable = (
-    table as table,
-    keyColumns as list,
-    nameColumn as text,
-    dataColumn as text,
-    itemKindColumn as text,
-    itemNameColumn as text,
-    isLeafColumn as text
-) as table =>
-    let
-        tableType = Value.Type(table),
-        newTableType = Type.AddTableKey(tableType, keyColumns, true) meta 
-        [
-            NavigationTable.NameColumn = nameColumn, 
-            NavigationTable.DataColumn = dataColumn,
-            NavigationTable.ItemKindColumn = itemKindColumn, 
-            Preview.DelayColumn = itemNameColumn, 
-            NavigationTable.IsLeafColumn = isLeafColumn
-        ],
-        navigationTable = Value.ReplaceType(table, newTableType)
-    in
-        navigationTable;
-```
-
-After copying this into your extension file, you'll update your `TripPinNavTable` function to add the navigation table fields.
+With this helper function in place, next update your `TripPinNavTable` function to add the navigation table fields.
 
 ```powerquery-m
 TripPinNavTable = (url as text) as table =>


### PR DESCRIPTION
Updating to follow the TripPin tutorial's [part 5](https://learn.microsoft.com/en-us/power-query/samples/trippin/5-paging/readme#tablegeneratebypage) which links to helper function code instead of embedding it inline in the tutorial page.

(This eases maintainability, potentially reducing the number of places that need to be updated if a future edit is made to one of these helper functions.)