### PR TITLE
Mention Essbase version that we currently support.

### DIFF
--- a/powerquery-docs/connectors/essbase.md
+++ b/powerquery-docs/connectors/essbase.md
@@ -20,7 +20,7 @@ ms.author: bezhan
 
 ## Prerequisites
 
-None
+Essbase 11.1.2.x version is supported.
 
 ## Capabilities Supported
 


### PR DESCRIPTION
On-prem Essbase from the [Oracle Enterprise Performance Management](https://blogs.oracle.com/proactivesupportepm/post/enterprise-performance-management-epm-11212-is-available) package is the only Essbase type that we support, which comes packaged with Essbase 11.1.2.4 as of writing. Should be mentioned to avoid confusing with Essbase Cloud.