### PR TITLE
Data Privacy Firewall: Wording Tweak + Typo Fix

### DIFF
--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -38,7 +38,7 @@ As part of folding, PQ sometimes may determine that the most efficient way to ex
 
 This is how unintentional data leakage can happen.
 
-Imagine if you were joining SQL data that included employee Social Security Numbers with the results of an external OData feed, and you suddenly discovered that the Social Security Numbers from SQL where being sent to the OData service. Bad news, right?
+Imagine if you were joining SQL data that included employee Social Security Numbers with the results of an external OData feed, and you suddenly discovered that the Social Security Numbers from SQL were being sent to the OData service. Bad news, right?
 
 This is the kind of scenario the Firewall is intended to prevent.
 
@@ -64,7 +64,7 @@ If you're not familiar with steps, you can view them on the right of the Power Q
 
 ### Partitions that reference other partitions
 
-When a query is evaluated with the Firewall on, the Firewall divides the query and all its dependencies into partitions (that is, groups of steps). Anytime one partition references something in another partition, the Firewall replaces the reference with a call to a special function called `Value.Firewall`. In other words, the Firewall doesn't allow partitions to access each other randomly. All references are modified to go through the Firewall. Think of the Firewall as a gatekeeper. A partition that references another partition must get the Firewall's permission to do so, and the Firewall controls whether or not the referenced data will be allowed into the partition.
+When a query is evaluated with the Firewall on, the Firewall divides the query and all its dependencies into partitions (that is, groups of steps). Anytime one partition references something in another partition, the Firewall replaces the reference with a call to a special function called `Value.Firewall`. In other words, the Firewall doesn't allow partitions to access each other directly. All references are modified to go through the Firewall. Think of the Firewall as a gatekeeper. A partition that references another partition must get the Firewall's permission to do so, and the Firewall controls whether or not the referenced data will be allowed into the partition.
 
 This all may seem pretty abstract, so let's look at an example.
 


### PR DESCRIPTION
* Proposing to change "randomly" -> "directly", as without the firewall, random access isn't occurring; rather, direct access is.