### PR TITLE
Firewall Static Grouping - Other Partition References

### DIFF
--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 10/31/2023
+ms.date: 11/3/2023
 ms.author: ehvonleh
 ---
 
@@ -154,12 +154,10 @@ Here's a high-level summary of the partitioning logic.
       * Note that "removing" a partition effectively includes it in whatever other partitions reference it.
       * Trimming parameter partitions allows parameter references used within data source function calls (for example, `Web.Contents(myUrl)`) to work, instead of throwing "partition can't reference data sources and other steps" errors.
     * Grouping (Static)
-      * Partitions are merged. In the resulting merged partitions, the following will be separate:
-        * Partitions in different queries.
-        * Partitions that don't reference other partitions (these are likely to access a data source).
-        * Partitions that reference other partitions (these should not access a data source).
-      * Special Case:
-        * As a query's output must come from a partition boundary, the partition corresponding to the query's return statement won't be merged with partitions that reference it.
+      * Partitions are merged. The goal is to merge the partitions in bottom-up dependency order so that in the resulting merged partitions, the following will be separate:
+        * Partitions in different queries
+        * Partitions that don't reference other partitions (and are thus allowed to access a data source)
+        * Partitions that reference other partitions (and are thus prohibited from accessing a data source)
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 10/12/2023
+ms.date: 10/23/2023
 ms.author: ehvonleh
 ---
 
@@ -157,7 +157,9 @@ Here's a high-level summary of the partitioning logic.
       * Partitions are merged. In the resulting merged partitions, the following will be separate:
         * Partitions in different queries.
         * Partitions that don't reference other partitions (these are likely to access a data source).
-        * Partitions that reference other partitions (these are not allowed to access a data source).
+        * Partitions that reference other partitions (these should not access a data source).
+      * Special Case:
+        * The query's final output partition will not have other partitions merged into it.
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 1/9/2023
+ms.date: 9/20/2023
 ms.author: ehvonleh
 ---
 
@@ -156,7 +156,7 @@ Here's a high-level summary of the partitioning logic.
     * Grouping (Static)
       * Partitions are merged, while maintaining separation between:
         * Partitions in different queries
-        * Partitions that reference other partitions vs. those that don't
+        * Partitions that reference multiple partitions vs. those that don't
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming
@@ -235,7 +235,7 @@ Next, we trim parameter partitions. Thus, DbServer gets implicitly included in t
 
 ![Trimmed firewall partitions.](media/data-privacy-firewall/firewall-steps-pane-2.png)
 
-Now we perform the static grouping. This maintains separation between partitions in separate queries (note for instance that the last two steps of Employees don't get grouped with the steps of Contacts), and between partitions that reference other partitions (such as the last two steps of Employees) and those that don't (such as the first three steps of Employees).
+Now we perform the static grouping. This maintains separation between partitions in separate queries (note for instance that the last two steps of Employees don't get grouped with the steps of Contacts), and between partitions that reference multiple partitions (such as the last two steps of Employees) and those that don't (such as the first three steps of Employees).
 
 ![Post static-grouping firewall partitions.](media/data-privacy-firewall/firewall-steps-pane-3.png)
 

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 10/23/2023
+ms.date: 10/31/2023
 ms.author: ehvonleh
 ---
 
@@ -159,7 +159,7 @@ Here's a high-level summary of the partitioning logic.
         * Partitions that don't reference other partitions (these are likely to access a data source).
         * Partitions that reference other partitions (these should not access a data source).
       * Special Case:
-        * The query's final output partition will not have other partitions merged into it.
+        * As a query's output must come from a partition boundary, the partition corresponding to the query's return statement won't be merged with partitions that reference it.
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -236,7 +236,7 @@ Next, we trim parameter partitions. Thus, DbServer gets implicitly included in t
 
 ![Trimmed firewall partitions.](media/data-privacy-firewall/firewall-steps-pane-2.png)
 
-Now we perform the static grouping. This maintains separation between partitions in separate queries (note for instance that the last two steps of Employees don't get grouped with the steps of Contacts), and between partitions that reference multiple partitions (such as the last two steps of Employees) and those that don't (such as the first three steps of Employees).
+Now we perform the static grouping. This maintains separation between partitions in separate queries (note for instance that the last two steps of Employees don't get grouped with the steps of Contacts), and between partitions that reference other partitions (such as the last two steps of Employees) and those that don't (such as the first three steps of Employees).
 
 ![Post static-grouping firewall partitions.](media/data-privacy-firewall/firewall-steps-pane-3.png)
 

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -154,7 +154,7 @@ Here's a high-level summary of the partitioning logic.
       * Note that "removing" a partition effectively includes it in whatever other partitions reference it.
       * Trimming parameter partitions allows parameter references used within data source function calls (for example, `Web.Contents(myUrl)`) to work, instead of throwing "partition can't reference data sources and other steps" errors.
     * Grouping (Static)
-      * Partitions are merged. The goal is to merge the partitions in bottom-up dependency order so that in the resulting merged partitions, the following will be separate:
+      * Partitions are merged in bottom-up dependency order. In the resulting merged partitions, the following will be separate:
         * Partitions in different queries
         * Partitions that don't reference other partitions (and are thus allowed to access a data source)
         * Partitions that reference other partitions (and are thus prohibited from accessing a data source)

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -154,9 +154,10 @@ Here's a high-level summary of the partitioning logic.
       * Note that "removing" a partition effectively includes it in whatever other partitions reference it.
       * Trimming parameter partitions allows parameter references used within data source function calls (for example, `Web.Contents(myUrl)`) to work, instead of throwing "partition can't reference data sources and other steps" errors.
     * Grouping (Static)
-      * Partitions are merged, while maintaining separation between:
-        * Partitions in different queries
-        * Partitions that reference multiple partitions vs. those that don't
+      * Partitions will only be merged if both are in the same query.
+      * A partition will be merged into another if it references the partition it is being merged into and either:
+        * It does not reference any other partitions.
+        * Or both it and the partition it is being merged into reference other partitions.
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 9/20/2023
+ms.date: 10/12/2023
 ms.author: ehvonleh
 ---
 
@@ -154,10 +154,10 @@ Here's a high-level summary of the partitioning logic.
       * Note that "removing" a partition effectively includes it in whatever other partitions reference it.
       * Trimming parameter partitions allows parameter references used within data source function calls (for example, `Web.Contents(myUrl)`) to work, instead of throwing "partition can't reference data sources and other steps" errors.
     * Grouping (Static)
-      * Partitions will only be merged if both are in the same query.
-      * A partition will be merged into another if it references the partition it is being merged into and either:
-        * It does not reference any other partitions.
-        * Or both it and the partition it is being merged into reference other partitions.
+      * Partitions are merged. In the resulting merged partitions, the following will be separate:
+        * Partitions in different queries.
+        * Partitions that don't reference other partitions (these are likely to access a data source).
+        * Partitions that reference other partitions (these are not allowed to access a data source).
 * Dynamic Phase
   * This phase depends on evaluation results, including information about data sources accessed by various partitions.
   * Trimming


### PR DESCRIPTION
From https://learn.microsoft.com/en-us/power-query/data-privacy-firewall#lets-partition:

> Now we perform the static grouping. This maintains separation between partitions ... that reference other partitions (such as the last two steps of Employees) and those that don't (such as the first three steps of Employees).

Since each of Employees' steps is in a separate partition prior to static grouping, this seems to imply that each of those steps (except for the first) references another partition so is *not* eligible for static grouping. However, the example given shows this is incorrect, as it has static grouping combining first three and last two steps of Employees. 

Not sure what the correct rule is here. Is this edit anywhere close to the correct rule? :-)

Don't think it is quite right, as the last step of Employees is statically grouped with its predecessor even though the last step does not directly reference other partitions. 