### PR TITLE
Typo in WWW-Authenticate

### DIFF
--- a/powerquery-docs/connector-authentication.md
+++ b/powerquery-docs/connector-authentication.md
@@ -121,7 +121,7 @@ Host: pbi.crm.dynamics.com
 Connection: Keep-Alive
 ```
 
-The service is then expected to respond with a **401** response with a **WWW_Authenticate** header indicating the Azure AD authorization URI to use. This response should include the tenant to sign into, or **/common/** if the resource isn’t associated with a specific tenant.
+The service is then expected to respond with a **401** response with a **WWW-Authenticate** header indicating the Azure AD authorization URI to use. This response should include the tenant to sign into, or **/common/** if the resource isn’t associated with a specific tenant.
 
 ```
 HTTP/1.1 401 Unauthorized


### PR DESCRIPTION
It seems from the example below and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate that it should be ```-``` and not ```_```


It came out of me praising the HTTP responses in the docs on Twitter, btw, which I think are fantastic.
https://twitter.com/larsw/status/1722163225586704789

<img width="453" alt="image" src="https://github.com/MicrosoftDocs/powerquery-docs/assets/88324093/8e0a21e9-07bc-4bab-becb-e27d3a4fbe00">


