### PR TITLE
Dynamic Grouping Rules Update

### DIFF
--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 1/4/2024
+ms.date: 1/22/2024
 ms.author: ehvonleh
 ---
 
@@ -166,11 +166,7 @@ Here's a high-level summary of the partitioning logic.
       * Doesn't reference any partitions that access data sources
       * Isn't cyclic
   * Grouping (Dynamic)
-    * Now that unnecessary partitions have been trimmed, try to create Source partitions that are as large as possible.
-    * Merge partitions in bottom-up dependency order. In the resulting merged partitions, the following will be separate:
-      * Partitions in different queries
-      * Partitions that don't reference other partitions (and are thus allowed to access a data source)
-      * Partitions that reference other partitions (and are thus prohibited from accessing a data source)
+    * Now that unnecessary partitions have been trimmed, try to create Source partitions that are as large as possible. Partitions are merged using the same rules described in the static grouping phase above.
 
 ## What does all this mean?
 

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -3,7 +3,7 @@ title: Behind the scenes of the Data Privacy Firewall
 description: Describes the purpose of the Data Privacy Firewall
 author: ehrenMSFT
 ms.topic: conceptual
-ms.date: 11/3/2023
+ms.date: 1/4/2024
 ms.author: ehvonleh
 ---
 
@@ -167,12 +167,10 @@ Here's a high-level summary of the partitioning logic.
       * Isn't cyclic
   * Grouping (Dynamic)
     * Now that unnecessary partitions have been trimmed, try to create Source partitions that are as large as possible.
-    * Merge all partitions with their input partitions if each of its inputs:
-      * Is part of the same query
-      * Doesn't reference any other partitions
-      * Is only referenced by the current partition
-      * Isn't the result (that is, final step) of a query
-      * Isn't cyclic
+    * Merge partitions in bottom-up dependency order. In the resulting merged partitions, the following will be separate:
+      * Partitions in different queries
+      * Partitions that don't reference other partitions (and are thus allowed to access a data source)
+      * Partitions that reference other partitions (and are thus prohibited from accessing a data source)
 
 ## What does all this mean?
 

--- a/powerquery-docs/data-privacy-firewall.md
+++ b/powerquery-docs/data-privacy-firewall.md
@@ -166,7 +166,7 @@ Here's a high-level summary of the partitioning logic.
       * Doesn't reference any partitions that access data sources
       * Isn't cyclic
   * Grouping (Dynamic)
-    * Now that unnecessary partitions have been trimmed, try to create Source partitions that are as large as possible. Partitions are merged using the same rules described in the static grouping phase above.
+    * Now that unnecessary partitions have been trimmed, try to create Source partitions that are as large as possible. This is done by merging the partitions using the same rules described in the static grouping phase above.
 
 ## What does all this mean?
 


### PR DESCRIPTION
@ehrenMSFT, should the dynamic grouping rules be updated so that they mirror the edit we made to static grouping last year? 

In essence, are the rules for static and dynamic grouping identical, just performed at different points using different information (i.e. just what can be learned by static analysis vs. the additional knowledge gained from [partial] evaluation results)?