### PR TITLE
Update dataverse.md

### DIFF
--- a/powerquery-docs/connectors/dataverse.md
+++ b/powerquery-docs/connectors/dataverse.md
@@ -171,7 +171,7 @@ Misspelling a column name might result in an error message about query folding i
 
 ### Accessing large semantic models
 
-Power BI semantic models contained in Dataverse can be very large. If you're using the Power Query Dataverse connector, any specific query that accesses the model has a fixed five (5) minute timeout irrespective of the size of the data [see limitations](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/dataverse-sql-query#limitations). So you might need to query the data multiple times to access all of the data in the model. Using multiple queries can take a considerable amount of time to return all the data.
+Power BI semantic models contained in Dataverse can be very large. If you're using the Power Query Dataverse connector, any specific query that accesses the model has a fixed five (5) minute timeout irrespective of the size of the data. For more information, go to [limitations](/power-apps/developer/data-platform/dataverse-sql-query#limitations). So you might need to query the data multiple times to access all of the data in the model. Using multiple queries can take a considerable amount of time to return all the data.
 
 If you're using the [Common Data Service (Legacy)](common-data-service-legacy.md) connector, you can use a single query to access all of the data in the semantic model. This connector works differently and returns the result in "pages" of 5-K records. Although the Common Data Service (Legacy) connector is more efficient in returning large amounts of data, it can still take a significant amount of time to return the result.
 

--- a/powerquery-docs/connectors/dataverse.md
+++ b/powerquery-docs/connectors/dataverse.md
@@ -171,7 +171,7 @@ Misspelling a column name might result in an error message about query folding i
 
 ### Accessing large semantic models
 
-Power BI semantic models contained in Dataverse can be very large. If you're using the Power Query Dataverse connector, any specific query that accesses the model must return less than 80 MB of data. So you might need to query the data multiple times to access all of the data in the model. Using multiple queries can take a considerable amount of time to return all the data.
+Power BI semantic models contained in Dataverse can be very large. If you're using the Power Query Dataverse connector, any specific query that accesses the model has a fixed five (5) minute timeout irrespective of the size of the data [see limitations](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/dataverse-sql-query#limitations). So you might need to query the data multiple times to access all of the data in the model. Using multiple queries can take a considerable amount of time to return all the data.
 
 If you're using the [Common Data Service (Legacy)](common-data-service-legacy.md) connector, you can use a single query to access all of the data in the semantic model. This connector works differently and returns the result in "pages" of 5-K records. Although the Common Data Service (Legacy) connector is more efficient in returning large amounts of data, it can still take a significant amount of time to return the result.
 


### PR DESCRIPTION
The documentation incorrectly mentions that the connector has 80MB size limit. There is no limit on the size of the data rather the limit is on the time-out. refere to this documentation https://learn.microsoft.com/en-us/power-apps/developer/data-platform/dataverse-sql-query#limitations

Also confirm this with Scott Sewell, PM Fabric CAT.