### PR TITLE
Update split-columns-positions.md to correct a note

### DIFF
--- a/powerquery-docs/split-columns-positions.md
+++ b/powerquery-docs/split-columns-positions.md
@@ -53,8 +53,8 @@ The result of that operation will give you a table with three columns.
 
 :::image type="content" source="media/split-columns-positions/into-columns-split-column-pre-final.png" alt-text="Sample transformed table after splitting column into columns by positions.":::
 
->[!Note]
->Power Query will split the column into only two columns. The name of the new columns will contain the same name as the original column. A suffix created by a dot and a number that represents the split section of the column will be appended to the name of the new columns.
+> [!Note]  
+> Power Query will split the column into as many columns as the number of positions specified. The names of the new columns will contain the same name as the original column, suffixed by a dot and a one-based number that represents the split section of the column. In the example above, the column named **Column1**  will be split into three columns named **Column1.1**, **Column1.2** and **Column1.3**.
 
 You can now change the name of the columns, and also define the data types of each column as follows:
 


### PR DESCRIPTION
The note updated in the commit uses ambiguous language. The first sentence especially can be misinterpreted.