### PR TITLE
Update MySQL .NET connector version

### DIFF
--- a/powerquery-docs/connectors/mysql-database.md
+++ b/powerquery-docs/connectors/mysql-database.md
@@ -24,7 +24,7 @@ ms.subservice: connectors
 
 ## Prerequisites
 > !NOTE]
-> You need mysql-connector-net-commercial-8.0.26.msi. Newer doesn't not work.
+> You need at least mysql-connector-net-commercial-8.0.26.msi. Use 8.0.28 to avoid "An error happened while reading data from the provider: 'Character set 'utf8mb3' is not supported by .Net Framework." error.
 
 You need to install the [Oracle MySQL Connector/NET](https://dev.mysql.com/downloads/connector/net/) package before using this connector in Power BI Desktop. For Power Query Online (dataflows) or Power BI service, if your MySQL server isn't cloud accessible and an on-premises data gateway is needed, the component Oracle MySQL Connector/NET must also be correctly installed on the machine running the on-premises data gateway. To determine if the package is installed correctly, open a PowerShell window and run the following command:
 

--- a/powerquery-docs/connectors/mysql-database.md
+++ b/powerquery-docs/connectors/mysql-database.md
@@ -23,6 +23,8 @@ ms.subservice: connectors
 > Some capabilities may be present in one product but not others due to deployment schedules and host-specific capabilities.
 
 ## Prerequisites
+> !NOTE]
+> You need mysql-connector-net-commercial-8.0.26.msi. Newer doesn't not work.
 
 You need to install the [Oracle MySQL Connector/NET](https://dev.mysql.com/downloads/connector/net/) package before using this connector in Power BI Desktop. For Power Query Online (dataflows) or Power BI service, if your MySQL server isn't cloud accessible and an on-premises data gateway is needed, the component Oracle MySQL Connector/NET must also be correctly installed on the machine running the on-premises data gateway. To determine if the package is installed correctly, open a PowerShell window and run the following command:
 


### PR DESCRIPTION
I found browsing the internet, in other url of the documentation (unfortunately without link)
![image](https://github.com/user-attachments/assets/fa1a830a-7190-47d7-a78b-6e56db331ab8)
and i verified that is true.

I kindly ask that the download URL be updated and that the only functional version be specified (as I did by adding a note).