### PR TITLE
Remove link to SQL server encryption set up in PostgreSQL doc

### DIFF
--- a/powerquery-docs/connectors/postgresql.md
+++ b/powerquery-docs/connectors/postgresql.md
@@ -67,7 +67,7 @@ Once the matching Npgsql provider is installed, you can connect to a PostgreSQL 
 
    :::image type="content" source="./media/postgresql/encryption-warning.png" alt-text="Screenshot of the Azure SQL database encryption support dialog.":::
 
-   Select **OK** to connect to the database by using an unencrypted connection, or follow the instructions in [Enable encrypted connections to the Database Engine](/sql/database-engine/configure-windows/enable-encrypted-connections-to-the-database-engine) to set up encrypted connections to PostgreSQL database.
+   Select **OK** to connect to the database by using an unencrypted connection. If an encrypted connection is desired, the PostgreSQL server must be set up to accommodate SSL connections (please see [PostgreSQL documentation](https://www.postgresql.org/docs/current/ssl-tcp.html) for guidance). Once completed, your machine may be required to install the PostgreSQL server's SSL certificate into its Trusted Root Certification Authorities.
 
 6. In **Navigator**, select the database information you want, then either select **Load** to load the data or **Transform Data** to continue transforming the data in Power Query editor.
 


### PR DESCRIPTION
PostgreSQL connector documentation has a link going to setting up encryption on a SQL server data source, which is irrelevant to PostgreSQL.

Replace the link to PostgreSQL documentation on SSL setup.